### PR TITLE
Support communication print

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -2,10 +2,10 @@
 
 import Homey, { Device } from 'homey';
 import UpdateListener from './lib/UpdateListner';
-import DucoApi from './lib/api/DucoApi';
-import NodeActionEnum from './lib/api/types/NodeActionEnum';
 import NodeHelper from './lib/NodeHelper';
 import DiscoveryService from './lib/DiscoveryService';
+import DucoApiFactory from './lib/api/DucoApiFactory';
+import DucoApi from './lib/api/types/DucoApi';
 
 export default class DucoApp extends Homey.App {
   ducoApi!: DucoApi
@@ -19,7 +19,11 @@ export default class DucoApp extends Homey.App {
       this.homey.settings.set('useHttps', true);
     }
 
-    this.ducoApi = DucoApi.create(this.homey);
+    if (this.homey.settings.get('useCommunicationPrintApi') === null) {
+      this.homey.settings.set('useCommunicationPrintApi', false);
+    }
+
+    this.ducoApi = DucoApiFactory.create(this.homey);
 
     const updateListner = UpdateListener.create(this.homey);
     updateListner.startListener();

--- a/drivers/co2-box-sensor/device.ts
+++ b/drivers/co2-box-sensor/device.ts
@@ -1,15 +1,16 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class CO2BoxSensorDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/co2-box-sensor/driver.ts
+++ b/drivers/co2-box-sensor/driver.ts
@@ -1,12 +1,13 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class CO2BoxSensorDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async onPairListDevices() {

--- a/drivers/co2-humidity-valve/device.ts
+++ b/drivers/co2-humidity-valve/device.ts
@@ -1,17 +1,18 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class Co2HumidityValveDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/co2-humidity-valve/driver.ts
+++ b/drivers/co2-humidity-valve/driver.ts
@@ -1,14 +1,15 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class Co2HumidityValveDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
 
     // init action card
     const changeVentilationStateAction = this.homey.flow.getActionCard('co2-humidity-valve__change_ventilation_state');

--- a/drivers/co2-room-sensor/device.ts
+++ b/drivers/co2-room-sensor/device.ts
@@ -1,17 +1,18 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class Co2RoomSensorDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/co2-room-sensor/driver.ts
+++ b/drivers/co2-room-sensor/driver.ts
@@ -1,14 +1,15 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
 import UpdateListener from '../../lib/UpdateListner';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class CO2RoomSensorDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
 
     // init action card
     const changeVentilationStateAction = this.homey.flow.getActionCard('co2-room-sensor__change_ventilation_state');

--- a/drivers/co2-valve/device.ts
+++ b/drivers/co2-valve/device.ts
@@ -1,17 +1,18 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
 import UpdateListener from '../../lib/UpdateListner';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class CO2ValveDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/co2-valve/driver.ts
+++ b/drivers/co2-valve/driver.ts
@@ -1,14 +1,15 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class CO2ValveDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
 
     // init action card
     const changeVentilationStateAction = this.homey.flow.getActionCard('co2-valve__change_ventilation_state');

--- a/drivers/ducobox-focus/device.ts
+++ b/drivers/ducobox-focus/device.ts
@@ -1,17 +1,18 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class DucoboxFocusDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/ducobox-focus/driver.ts
+++ b/drivers/ducobox-focus/driver.ts
@@ -1,14 +1,15 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
 import UpdateListener from '../../lib/UpdateListner';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class DucoboxFocusDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
 
     // init action card
     const changeVentilationStateAction = this.homey.flow.getActionCard('ducobox-focus__change_ventilation_state');

--- a/drivers/ducobox-silent-connect/device.ts
+++ b/drivers/ducobox-silent-connect/device.ts
@@ -1,17 +1,18 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class DucoboxSilentConnectDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/ducobox-silent-connect/driver.ts
+++ b/drivers/ducobox-silent-connect/driver.ts
@@ -1,14 +1,15 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
 import UpdateListener from '../../lib/UpdateListner';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class DucoboxSilentConnectDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
 
     // init action card
     const changeVentilationStateAction = this.homey.flow.getActionCard('ducobox-silent-connect__change_ventilation_state');

--- a/drivers/humidity-box-sensor/device.ts
+++ b/drivers/humidity-box-sensor/device.ts
@@ -1,15 +1,16 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class HumidityBoxSensorDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/humidity-box-sensor/driver.ts
+++ b/drivers/humidity-box-sensor/driver.ts
@@ -1,12 +1,13 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class HumidityBoxSensorDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async onPairListDevices() {

--- a/drivers/humidity-room-sensor/device.ts
+++ b/drivers/humidity-room-sensor/device.ts
@@ -1,17 +1,18 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class HumidityRoomSensorDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/humidity-room-sensor/driver.ts
+++ b/drivers/humidity-room-sensor/driver.ts
@@ -1,14 +1,15 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class HumidityRoomSensorDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
 
     // init action card
     const changeVentilationStateAction = this.homey.flow.getActionCard('humidity-room-sensor__change_ventilation_state');

--- a/drivers/humidity-valve/device.ts
+++ b/drivers/humidity-valve/device.ts
@@ -1,17 +1,18 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class HumidityValveDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/humidity-valve/driver.ts
+++ b/drivers/humidity-valve/driver.ts
@@ -1,14 +1,15 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class HumidityValveDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
 
     // init action card
     const changeVentilationStateAction = this.homey.flow.getActionCard('humidity-valve__change_ventilation_state');

--- a/drivers/user-control/device.ts
+++ b/drivers/user-control/device.ts
@@ -1,17 +1,18 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class UserControlDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/user-control/driver.ts
+++ b/drivers/user-control/driver.ts
@@ -1,14 +1,15 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class UserControlDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
 
     // init action card
     const changeVentilationStateAction = this.homey.flow.getActionCard('user-control__change_ventilation_state');

--- a/drivers/valve/device.ts
+++ b/drivers/valve/device.ts
@@ -1,17 +1,18 @@
 import DucoDevice from '../../lib/homey/DucoDevice';
 import NodeInterface from '../../lib/api/types/NodeInterface';
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import DucoBoxCapabilityValues from '../../lib/types/DucoBoxCapabilityValues';
 import FlowHelper from '../../lib/FlowHelper';
 import UpdateListener from '../../lib/UpdateListner';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class ValveDevice extends DucoDevice {
   ducoApi!: DucoApi
 
   async onInit() {
     await this.initCapabilities();
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
   }
 
   async initCapabilities() {

--- a/drivers/valve/driver.ts
+++ b/drivers/valve/driver.ts
@@ -1,14 +1,15 @@
-import DucoApi from '../../lib/api/DucoApi';
+import DucoApi from '../../lib/api/types/DucoApi';
 import NodeHelper from '../../lib/NodeHelper';
 import DucoDriver from '../../lib/homey/DucoDriver';
 import NodeActionEnum from '../../lib/api/types/NodeActionEnum';
 import UpdateListener from '../../lib/UpdateListner';
+import DucoApiFactory from '../../lib/api/DucoApiFactory';
 
 class ValveDriver extends DucoDriver {
   ducoApi!: DucoApi
 
   async onInit() {
-    this.ducoApi = DucoApi.create(this.homey);
+    this.ducoApi = DucoApiFactory.create(this.homey);
 
     // init action card
     const changeVentilationStateAction = this.homey.flow.getActionCard('valve__change_ventilation_state');

--- a/lib/DiscoveryService.ts
+++ b/lib/DiscoveryService.ts
@@ -66,13 +66,20 @@ export default class DiscoveryService {
         }
         discoveredDucoBoxes.push(discoveryResult);
         this.homey.settings.set('discoveredDucoBoxes', discoveredDucoBoxes);
-        
+
         // save the first result as hostname when no hostname is set and the result address is valid
-        if (!this.homey.settings.get('hostname') && discoveryResult.address && discoveryResult.address !== '127.0.0.1' && discoveryResult.address !== '0.0.0.0') {
-            this.homey.settings.set('hostname', discoveryResult.address);
-            this.homey.settings.set('useHttps', parseInt(discoveryResult.port) === 80 ? 'http' : 'https');
-            
-            this.homey.log('Hostname in settings is empty, hostname set to '+discoveryResult.address);
+        if (!this.homey.settings.get('hostname')) {
+            if (discoveryResult.host && discoveryResult.host !== '127.0.0.1' && discoveryResult.host !== '0.0.0.0') {
+                this.homey.settings.set('hostname', discoveryResult.host);
+                this.homey.settings.set('useHttps', parseInt(discoveryResult.port) === 80 ? 'http' : 'https');
+                
+                this.homey.log('Hostname in settings is empty, hostname set from discovery host to '+discoveryResult.host);
+            } else if (discoveryResult.address && discoveryResult.address !== '127.0.0.1' && discoveryResult.address !== '0.0.0.0') {
+                this.homey.settings.set('hostname', discoveryResult.address);
+                this.homey.settings.set('useHttps', parseInt(discoveryResult.port) === 80 ? 'http' : 'https');
+                
+                this.homey.log('Hostname in settings is empty, hostname set from discovery address to '+discoveryResult.address);
+            }
         }
 
         this.homey.log('Device added to the discovered duco boxes list, current number of boxes: '+discoveredDucoBoxes.length);

--- a/lib/UpdateListner.ts
+++ b/lib/UpdateListner.ts
@@ -1,10 +1,11 @@
 'use strict';
 
 import Homey from 'homey/lib/Homey';
-import DucoApi from './api/DucoApi';
+import DucoApi from './api/types/DucoApi';
 import NodeInterface from './api/types/NodeInterface';
 import NodeHelper from './NodeHelper';
 import DucoDriver from './homey/DucoDriver';
+import DucoApiFactory from './api/DucoApiFactory';
 
 let updateListener: UpdateListener|null = null;
 
@@ -18,7 +19,7 @@ export default class UpdateListener {
     updatingDevices: boolean
 
     constructor(homey: Homey) {
-        this.ducoApi = DucoApi.create(homey);
+        this.ducoApi = DucoApiFactory.create(homey);
         this.homey = homey;
         this.timeoutId = null;
         this.updatingDevices = false;

--- a/lib/api/DucoApiFactory.ts
+++ b/lib/api/DucoApiFactory.ts
@@ -1,0 +1,22 @@
+'use strict';
+
+import Homey from 'homey/lib/Homey';
+import DucoApi from './types/DucoApi';
+import DucoCommunicationPrintApi from './DucoCommunicationPrintApi';
+import DucoRestApi from './DucoRestApi';
+
+let ducoApi: DucoApi|null = null;
+
+export default class DucoApiFactory {
+    static create(homey: Homey): DucoApi {
+      if (!ducoApi) {
+        const useCommunicationPrintApi = homey.settings.get('useCommunicationPrintApi');
+
+        ducoApi = useCommunicationPrintApi
+          ? new DucoCommunicationPrintApi(homey)
+          : new DucoRestApi(homey);
+      }
+
+      return ducoApi;
+    }
+}

--- a/lib/api/DucoCommunicationPrintApi.ts
+++ b/lib/api/DucoCommunicationPrintApi.ts
@@ -1,0 +1,88 @@
+'use strict';
+
+import Homey from 'homey/lib/Homey';
+import NodeInterface from './types/NodeInterface';
+import PostNodeAction from './types/PostNodeAction';
+import HttpClient from './HttpClient';
+import { NodeInfoGet } from './types/NodeInfoGet';
+import DucoApi from './types/DucoApi';
+
+export default class DucoCommunicationPrintApi implements DucoApi {
+
+    httpClient: HttpClient
+
+    constructor(homey: Homey) {
+        this.httpClient = new HttpClient(homey);
+    }
+
+    async getNodes() : Promise<NodeInterface[]> {
+        const response = await this.httpClient.get('/nodelist');
+                
+        const result = JSON.parse(response) as { nodelist: number[] };
+        const nodes: NodeInterface[] = [];
+
+        for (const node of result.nodelist) {
+            const response  = await this.httpClient.get('/nodeinfoget?node=' + node);
+                
+            const result = JSON.parse(response) as NodeInfoGet;
+            nodes.push(this.toNodeInterface(result));
+        }
+
+        return nodes;
+    }
+
+    async postNodeAction(nodeId: number, postData: PostNodeAction) : Promise<void> {
+        const response = await this.httpClient.get('/nodesetoperstate?node='+nodeId+'&value='+postData.Val+'&t=' + new Date().getTime())
+        const isSuccess = response === `SUCCESS`;
+        if (!isSuccess) {
+            throw new Error('Error post node action.');
+        }
+    }
+
+    private toNodeInterface(result: NodeInfoGet) : NodeInterface {
+        return {
+            Node: result.node,
+            General: {
+                Type: {
+                    Val: result.devtype,
+                },
+                SubType: {
+                    Val: result.subtype,
+                },
+                NetworkType: {
+                    Val: result.netw,
+                },
+                Parent: {
+                    Val: result.prnt,
+                },
+                Asso: {
+                    Val: result.asso,
+                },
+                Name: {
+                    Val: result.location,
+                },
+                Identify: {
+                    Val: 0,
+                },
+            },
+            Ventilation: {
+                State: {
+                    Val: result.state,
+                },
+                TimeStateRemain: {
+                    Val: result.cntdwn,
+                },
+                TimeStateEnd: {
+                    Val: result.endtime,
+                },
+                Mode: {
+                    Val: result.mode,
+                },
+                FlowLvlTgt: {
+                    Val: result.trgt,
+                },
+            },
+            Sensor: undefined,
+        };
+    }
+}

--- a/lib/api/DucoRestApi.ts
+++ b/lib/api/DucoRestApi.ts
@@ -4,23 +4,14 @@ import Homey from 'homey/lib/Homey';
 import NodeInterface from './types/NodeInterface';
 import PostNodeAction from './types/PostNodeAction';
 import HttpClient from './HttpClient';
+import DucoApi from './types/DucoApi';
 
-let ducoApi: DucoApi|null = null;
-
-export default class DucoApi {
+export default class DucoRestApi implements DucoApi {
 
     httpClient: HttpClient
 
     constructor(homey: Homey) {
         this.httpClient = new HttpClient(homey);
-    }
-
-    static create(homey: Homey) {
-        if (null === ducoApi) {
-            ducoApi = new DucoApi(homey);
-        }
-
-        return ducoApi;
     }
 
     getNodes() : Promise <NodeInterface[]> {
@@ -34,7 +25,9 @@ export default class DucoApi {
                         return reject(new Error('Error obtaining nodes.'));
                     }
                 })
-                .catch(error => reject(error));
+                .catch(error => {
+                    reject(error);
+                });
         });
     }
 

--- a/lib/api/types/DucoApi.ts
+++ b/lib/api/types/DucoApi.ts
@@ -1,0 +1,9 @@
+'use strict';
+
+import NodeInterface from './NodeInterface';
+import PostNodeAction from './PostNodeAction';
+
+export default interface DucoApi {
+    getNodes() : Promise <NodeInterface[]>;
+    postNodeAction(nodeId: number, postData: PostNodeAction) : Promise<any>;
+}

--- a/lib/api/types/NodeInfoGet.ts
+++ b/lib/api/types/NodeInfoGet.ts
@@ -1,0 +1,28 @@
+export interface NodeInfoGet {
+  node: number;
+  devtype: string; // e.g. BOX
+  subtype: number;
+  netw: string;
+  addr: number;
+  sub: number;
+  prnt: number;
+  asso: number;
+  location: string;
+  state: string;
+  cntdwn: number;
+  endtime: number;
+  mode: string;
+  trgt: number;
+  actl: number;
+  ovrl: number;
+  snsr: number;
+  cerr: number;
+  swversion: string;
+  serialnb: string;
+  temp: number;
+  co2: number;
+  rh: number;
+  error: string;
+  show: number;
+  link: number;
+};

--- a/locales/en.json
+++ b/locales/en.json
@@ -4,6 +4,7 @@
         "hostname": "IP / Hostname DucoBox",
         "hostname_hint": "This is the IP address of the Connectivity Board on your local network.",
         "use_https": "Use https",
+        "use_communication_print_api": "Use communication print api",
         "nothing_found": "Nothing found.",
         "name": "Name",
         "url": "URL",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -4,6 +4,7 @@
         "hostname": "IP / Hostnaam DucoBox",
         "hostname_hint": "Dit is het IP adres van de Connectivity Board op je lokale netwerk.",
         "use_https": "Gebruik https",
+        "use_communication_print_api": "Gebruik communication print api",
         "nothing_found": "Niets gevonden.",
         "name": "Naam",
         "url": "URL",

--- a/settings/index.html
+++ b/settings/index.html
@@ -23,6 +23,12 @@
         <span class="homey-form-checkbox-text" data-i18n="settings.use_https">Use https</label>
       </label>
 
+      <label class="homey-form-checkbox">
+        <input type="checkbox" id="useCommunicationPrintApiInput" class="homey-form-checkbox-input" />
+        <span class="homey-form-checkbox-checkmark"></span>
+        <span class="homey-form-checkbox-text" data-i18n="settings.use_communication_print_api">Use communication print api</label>
+      </label>
+
       <button id="searchButton" class="homey-button-secondary-shadow-full" data-i18n="settings.search">Search for Docuboxes</button>
       <br />
       <button id="saveButton" class="homey-button-primary-full" data-i18n="settings.save">Save changes</button>
@@ -39,6 +45,7 @@
       const searchView = document.getElementById("searchView");
       const hostnameInputElement = document.getElementById("hostnameInput");
       const useHttpsInputElement = document.getElementById("useHttpsInput");
+      const useCommunicationPrintApiInputElement = document.getElementById("useCommunicationPrintApiInput");
       const searchButtonElement = document.getElementById("searchButton");
       const cancelSearchButtonElement = document.getElementById("cancelSearchButton");
       const saveButtonElement = document.getElementById("saveButton");
@@ -62,6 +69,15 @@
           }
 
           useHttpsInputElement.checked = useHttps;
+        });
+
+        // init value for use communication print api checkbox
+        Homey.get("useCommunicationPrintApi", function (err, useCommunicationPrintApi) {
+          if (err) {
+            return Homey.alert(err);
+          }
+
+          useCommunicationPrintApiInputElement.checked = useCommunicationPrintApi;
         });
 
         // handle search button click
@@ -96,6 +112,7 @@
 
           Homey.set("hostname", hostnameInputElement.value, handleSaveCallback);
           Homey.set("useHttps", useHttpsInputElement.checked, handleSaveCallback);
+          Homey.set("useCommunicationPrintApi", useCommunicationPrintApiInputElement.checked, handleSaveCallback);
         });
       }
 


### PR DESCRIPTION
This change supports discovering and setting the state of devices over the communication print API. I have this communication print and it works perfectly fine, so I see no reason to upgrade to the new connectivity board. I have tested this myself.

I first attempted to create a separate driver and just have that connect over the different API, but that was not possible because the `.getNodes()` is called throughout the app.

I now implemented a setting "use communication print api". This switches the API to the communication print instead of the regular rest api.

In a separate commit I made a change to prefer .host if set on the discovery result. In my case this is e.g. `duco001.local` and this is preferred over .address which contains an IP because the host will stay the same throughout and the IP will change.